### PR TITLE
Update settings for branch protection rule on cdt-infra repo

### DIFF
--- a/otterdog/eclipse-cdt.jsonnet
+++ b/otterdog/eclipse-cdt.jsonnet
@@ -68,10 +68,7 @@ orgs.newOrg('eclipse-cdt') {
       web_commit_signoff_required: false,
       branch_protection_rules: [
         orgs.newBranchProtectionRule('master') {
-          required_approving_review_count: null,
-          requires_pull_request: false,
-          requires_status_checks: false,
-          requires_strict_status_checks: true,
+          required_approving_review_count: 0,
         },
       ],
     },


### PR DESCRIPTION
The bpr shall

- require a PR
- set the approval count to 0
- enforce status checks (which enforces the eca check)