### PR TITLE
Loosen branch protection rules to just primary and release ones

### DIFF
--- a/otterdog/eclipse-cdt.jsonnet
+++ b/otterdog/eclipse-cdt.jsonnet
@@ -64,7 +64,9 @@ orgs.newOrg('eclipse-cdt') {
         default_workflow_permissions: "write",
       },
       branch_protection_rules: [
-        custom_branch_protection_rule('*'),
+        custom_branch_protection_rule('main'),
+        custom_branch_protection_rule('org.eclipse.remote-master'),
+        custom_branch_protection_rule('cdt_*'),
       ],
     },
     orgs.newRepo('cdt-infra') {
@@ -93,7 +95,8 @@ orgs.newOrg('eclipse-cdt') {
         actions_can_approve_pull_request_reviews: false,
       },
       branch_protection_rules: [
-        custom_branch_protection_rule('*'),
+        custom_branch_protection_rule('master'),
+        custom_branch_protection_rule('cdt_lsp_*'),
       ],
     },
     orgs.newRepo('cdt-new-managedbuild-prototype') {


### PR DESCRIPTION
As recommended here https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/4330#note_1798317

PS at some future time we may try to resolve cdt-lsp calling default branch master and cdt calling default branch main

@ghentschke FYI with this change merged it means that temporary branches will be deletable by committers.