### PR TITLE
Archive the cdt-infra repo

### DIFF
--- a/otterdog/eclipse-cdt.jsonnet
+++ b/otterdog/eclipse-cdt.jsonnet
@@ -66,6 +66,7 @@ orgs.newOrg('eclipse-cdt') {
       ],
     },
     orgs.newRepo('cdt-infra') {
+      archived: true,
       allow_merge_commit: true,
       allow_update_branch: false,
       default_branch: "master",


### PR DESCRIPTION
See https://github.com/eclipse-cdt/cdt-infra/pull/66 where all content on master deleted in preparation for archiving and https://github.com/eclipse-cdt/cdt-infra/pull/67 where the readme was added/restored.