### PR TITLE
Add homebrew-tools repository

### DIFF
--- a/otterdog/eclipse-cdt.jsonnet
+++ b/otterdog/eclipse-cdt.jsonnet
@@ -119,5 +119,17 @@ orgs.newOrg('tools.cdt', 'eclipse-cdt') {
         custom_branch_protection_rule('*'),
       ],
     },
+    orgs.newRepo('homebrew-tools') {
+      allow_update_branch: false,
+      delete_branch_on_merge: false,
+      description: "Additional formulae for the Homebrew package manager",
+      web_commit_signoff_required: false,
+      workflows+: {
+        actions_can_approve_pull_request_reviews: false,
+      },
+      branch_protection_rules: [
+        custom_branch_protection_rule('*'),
+      ],
+    },
   ],
 }


### PR DESCRIPTION
A new repository providing formulae for the Homebrew package manager.

Relates to: https://github.com/eclipse-cdt/cdt/discussions/1225